### PR TITLE
Fix symlink targets

### DIFF
--- a/src/vinetto/thumbCMMM.py
+++ b/src/vinetto/thumbCMMM.py
@@ -235,7 +235,7 @@ def process(infile, fileThumbsDB, iThumbsDBSize):
                     strFileName = config.ESEDB.dictRecord["IURL"].split("/")[-1].split("?")[0]
                 if (strFileName != None):
                     if (config.ARGS.symlinks):  # ...implies config.ARGS.outdir
-                        strTarget = config.ARGS.outdir + config.THUMBS_SUBDIR + "/" + strCleanFileName + "." + strExt
+                        strTarget = config.THUMBS_SUBDIR + "/" + strCleanFileName + "." + strExt
                         setSymlink(strTarget, config.ARGS.outdir + strFileName)
 
                         fileURL = open(config.ARGS.outdir + config.THUMBS_FILE_URLS, "a+")

--- a/src/vinetto/thumbOLE.py
+++ b/src/vinetto/thumbOLE.py
@@ -384,7 +384,7 @@ def process(infile, fileThumbsDB, iThumbsDBSize):
                         strCatEntryTimestamp = utils.getFormattedWinToPyTimeUTC(iCatEntryTimestamp)
                         strCatEntryName      = utils.decodeBytes(bstrCatEntryName)
                         if (config.ARGS.symlinks):  # ...implies config.ARGS.outdir
-                            strTarget = config.ARGS.outdir + config.THUMBS_SUBDIR + "/" + strCatEntryID + ".jpg"
+                            strTarget = config.THUMBS_SUBDIR + "/" + strCatEntryID + ".jpg"
                             utils.setSymlink(strTarget, config.ARGS.outdir + strCatEntryName)
 
                         # Add a "catalog" entry...


### PR DESCRIPTION
A symlink's target is relative to itself, regardless of where you are when creating the symlink.

Previously this created symlinks with non-existent targets if the output directory was not `.`.